### PR TITLE
update flex for contact image

### DIFF
--- a/sass/imports/_faq.scss
+++ b/sass/imports/_faq.scss
@@ -63,7 +63,7 @@
 
   &__contact-image {
     width: 0;
-    flex: 0.2;
+    flex: 1;
     object-fit: cover;
     @include smaller-than-tablet {
       max-height: 300px;


### PR DESCRIPTION
This fixes the display of the image size in safari and chrome.